### PR TITLE
fixed missing app_settings module

### DIFF
--- a/django_mkdocs/urls.py
+++ b/django_mkdocs/urls.py
@@ -1,5 +1,5 @@
 from django.urls import path, re_path
-from . import views
+from django_mkdocs import views
 from django.contrib import admin
 
 admin.autodiscover()

--- a/django_mkdocs/views.py
+++ b/django_mkdocs/views.py
@@ -1,5 +1,5 @@
 from django.http import HttpResponse, Http404, HttpResponseRedirect
-from . import app_settings
+from django_mkdocs import app_settings
 from django.views.static import serve
 import mimetypes
 from django.contrib.auth.decorators import login_required


### PR DESCRIPTION
Because in the urls.py and view.py the app_settings module is imported using
`from . import app_settings`
the plugin does not work.
I changed it to from django_mkdocs and it works like a charm.

Please feel free to include my pull request in the next release.

BR

Dave